### PR TITLE
Fix HTML syntax on Old Standard page

### DIFF
--- a/oldstandard.html
+++ b/oldstandard.html
@@ -71,7 +71,7 @@
   left: 140px;
   height: 115px;
 					">
-					<span>Long tail with hairline terminal going upwards/span>
+					<span>Long tail with hairline terminal going upwards</span>
 				</div>
 				<div class="line" style="
   left: 272px;


### PR DESCRIPTION
Adds missing `<` character in the 'long tail' annotation.

_Bug pre-patch:_

![screen shot 2015-09-28 at 10 15 13 pm](https://cloud.githubusercontent.com/assets/2704010/10155813/6c57b4ac-662e-11e5-85b6-d3e8a5e45939.png)
